### PR TITLE
Fuel-tier-count

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ pickles/vat-*
 pickles/*.pkl
 *.pkl
 *.csv
+*.xlsx

--- a/driftpy/derive_authority_from_user_account.py
+++ b/driftpy/derive_authority_from_user_account.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""
+Drift Authority Derivation Script
+
+This script retrieves the authority public key for a given Drift user account address.
+Unlike deriving a user account from an authority (a one-way process), this script
+works by fetching the user account's on-chain data, where the authority is
+stored as a field.
+
+This approach is best for single, ad-hoc lookups. For applications requiring
+bulk lookups or real-time monitoring, using the UserMap would be more efficient.
+
+Usage:
+    python derive_authority_from_user_account.py <USER_ACCOUNT_PUBKEY> [--rpc <RPC_URL>]
+
+Example:
+    python derive_authority_from_user_account.py 5wDD59a3iRd2aP2e3n4r5s6t7u8v9w0x1y2z3a4b5c6d7e8f9g0h1i2j3k4l5m6n7o8p
+
+Requirements:
+    - Python 3.7+
+    - driftpy
+    - anchorpy
+    - solders
+    - solana
+    - python-dotenv
+"""
+
+import os
+import sys
+import asyncio
+import argparse
+from dotenv import load_dotenv
+
+from solders.pubkey import Pubkey
+from solders.keypair import Keypair
+from anchorpy import Wallet
+from solana.rpc.async_api import AsyncClient
+from driftpy.drift_client import DriftClient
+from driftpy.accounts.get_accounts import get_user_account
+from driftpy.types import UserAccount
+
+# Load environment variables from a .env file if present
+load_dotenv()
+
+async def get_authority_from_user_account(client: DriftClient, user_account_pubkey: Pubkey) -> Pubkey | None:
+    """
+    Fetches the user account data from the blockchain and returns its authority.
+
+    Args:
+        client: An initialized DriftClient instance.
+        user_account_pubkey: The public key of the user account to look up.
+
+    Returns:
+        The authority public key, or None if the account is not found or an error occurs.
+    """
+    try:
+        user_account: UserAccount = await get_user_account(client.program, user_account_pubkey)
+        return user_account.authority
+    except Exception as e:
+        print(f"Error fetching account data for {user_account_pubkey}: {e}", file=sys.stderr)
+        return None
+
+async def main():
+    """
+    Main function to parse arguments, set up the Drift client, and find the authority.
+    """
+    parser = argparse.ArgumentParser(
+        description="Retrieve the authority for a given Drift user account address.",
+        formatter_class=argparse.RawTextHelpFormatter,
+        epilog="""
+Example usage:
+  python derive_authority_from_user_account.py HnxVcr2tftdZfSgZqAnr5sV1d1d8Z4wX9Y3Z5d6c8b2a
+  python derive_authority_from_user_account.py HnxVcr2tftdZfSgZqAnr5sV1d1d8Z4wX9Y3Z5d6c8b2a --rpc https://api.mainnet-beta.solana.com
+"""
+    )
+    parser.add_argument(
+        "user_account",
+        type=str,
+        help="The public key of the user account."
+    )
+    parser.add_argument(
+        "--rpc",
+        help="RPC URL for the Solana cluster (defaults to RPC_URL env var)."
+    )
+
+    args = parser.parse_args()
+
+    # --- Client Setup ---
+    rpc_url = args.rpc or os.environ.get("RPC_URL")
+    if not rpc_url:
+        print("Error: RPC URL is required. Set the RPC_URL environment variable or use the --rpc argument.", file=sys.stderr)
+        return 1
+
+    dummy_keypair = Keypair()
+    wallet = Wallet(dummy_keypair)
+    connection = AsyncClient(rpc_url)
+    drift_client = DriftClient(connection, wallet)
+
+    # --- Authority Lookup ---
+    try:
+        user_account_pubkey = Pubkey.from_string(args.user_account)
+    except Exception:
+        print(f"Error: Invalid user account public key provided: '{args.user_account}'", file=sys.stderr)
+        await connection.close()
+        return 1
+
+    print(f"Attempting to find authority for user account: {user_account_pubkey}\n")
+
+    authority_pubkey = await get_authority_from_user_account(drift_client, user_account_pubkey)
+
+    if authority_pubkey:
+        print(f"Successfully found authority:")
+        print(f"  -> {authority_pubkey}")
+    else:
+        print("Could not determine the authority. The user account may not exist or there was a network issue.")
+        await connection.close()
+        return 1
+        
+    # --- Cleanup ---
+    await connection.close()
+    
+    return 0
+
+if __name__ == "__main__":
+    try:
+        exit_code = asyncio.run(main())
+        sys.exit(exit_code)
+    except KeyboardInterrupt:
+        print("\nProcess interrupted by user.")
+        sys.exit(1)

--- a/driftpy/derive_user_account_from_authority.py
+++ b/driftpy/derive_user_account_from_authority.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""
+Drift User Account Derivation Script
+
+This script derives Drift user account public keys from a given authority address.
+It demonstrates how to use the `get_user_account_public_key` function from the
+driftpy SDK to generate sub-account addresses.
+
+The script accepts an authority's public key and the number of user accounts
+to derive as command-line arguments.
+
+Usage:
+    python derive_user_account_from_authority.py <AUTHORITY_PUBKEY> <NUM_ACCOUNTS> [--rpc <RPC_URL>]
+
+Example:
+    python derive_user_account_from_authority.py Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS 5
+
+Requirements:
+    - Python 3.7+
+    - driftpy
+    - anchorpy
+    - solders
+    - solana
+    - python-dotenv
+"""
+
+import os
+import sys
+import asyncio
+import argparse
+from dotenv import load_dotenv
+
+from solders.pubkey import Pubkey
+from solders.keypair import Keypair
+from anchorpy import Wallet
+from solana.rpc.async_api import AsyncClient
+
+from driftpy.drift_client import DriftClient
+from driftpy.addresses import get_user_account_public_key
+
+# Load environment variables from a .env file if present
+load_dotenv()
+
+def derive_user_accounts(program_id: Pubkey, authority: Pubkey, num_accounts: int) -> list[Pubkey]:
+    """
+    Derives a specified number of user account public keys for a given authority.
+
+    Args:
+        program_id: The public key of the Drift program.
+        authority: The public key of the user's main wallet.
+        num_accounts: The number of sub-accounts to derive.
+
+    Returns:
+        A list of derived user account public keys.
+    """
+    accounts = []
+    for i in range(num_accounts):
+        user_account_pubkey = get_user_account_public_key(
+            program_id=program_id,
+            authority=authority,
+            sub_account_id=i
+        )
+        accounts.append(user_account_pubkey)
+    return accounts
+
+async def main():
+    """
+    Main function to parse arguments, set up the Drift client, and derive accounts.
+    """
+    parser = argparse.ArgumentParser(
+        description="Derive Drift user account addresses from an authority public key.",
+        formatter_class=argparse.RawTextHelpFormatter,
+        epilog="""
+Example usage:
+  python derive_user_account_from_authority.py Bx11bA9p9q54cWg2F2P33n2123f11a4A1F9d11Ea1b 10
+  python derive_user_account_from_authority.py Bx11bA9p9q54cWg2F2P33n2123f11a4A1F9d11Ea1b 5 --rpc https://api.mainnet-beta.solana.com
+"""
+    )
+    parser.add_argument(
+        "authority",
+        type=str,
+        help="The public key of the authority wallet."
+    )
+    parser.add_argument(
+        "num_accounts",
+        type=int,
+        help="The number of user sub-accounts to derive (e.g., 5)."
+    )
+    parser.add_argument(
+        "--rpc",
+        help="RPC URL for the Solana cluster (defaults to RPC_URL env var)."
+    )
+
+    args = parser.parse_args()
+
+    # --- Client Setup ---
+    # Get RPC URL from arguments or environment variable
+    rpc_url = args.rpc or os.environ.get("RPC_URL")
+    if not rpc_url:
+        print("Error: RPC URL is required. Set the RPC_URL environment variable or use the --rpc argument.", file=sys.stderr)
+        return 1
+    
+    # We use a dummy keypair since we're only deriving addresses and not sending transactions.
+    # The DriftClient requires a wallet for initialization.
+    dummy_keypair = Keypair()
+    wallet = Wallet(dummy_keypair)
+    
+    # Set up the connection to the Solana RPC node
+    connection = AsyncClient(rpc_url)
+    
+    # Initialize the DriftClient. This is needed to get the program ID.
+    # We don't need to subscribe to any accounts since address derivation is a local, offline operation.
+    drift_client = DriftClient(connection, wallet)
+    
+    # --- Address Derivation ---
+    try:
+        authority_pubkey = Pubkey.from_string(args.authority)
+    except Exception:
+        print(f"Error: Invalid authority public key provided: '{args.authority}'", file=sys.stderr)
+        await connection.close()
+        return 1
+
+    if args.num_accounts <= 0:
+        print("Error: Number of accounts must be a positive integer.", file=sys.stderr)
+        await connection.close()
+        return 1
+    
+    print(f"Deriving {args.num_accounts} user account(s) for authority: {args.authority}\n")
+    
+    # The program ID is required for PDA derivation. We get it from the client instance.
+    program_id = drift_client.program.program_id
+    
+    user_accounts = derive_user_accounts(program_id, authority_pubkey, args.num_accounts)
+    
+    for i, account_pubkey in enumerate(user_accounts):
+        print(f"Sub-account ID {i}: {account_pubkey}")
+
+    # --- Cleanup ---
+    await connection.close()
+    
+    return 0
+
+if __name__ == "__main__":
+    # asyncio.run is used to execute the async main function
+    try:
+        exit_code = asyncio.run(main())
+        sys.exit(exit_code)
+    except KeyboardInterrupt:
+        print("\nProcess interrupted by user.")
+        sys.exit(1)

--- a/driftpy/get_protected_market_maker_count_onchain.py
+++ b/driftpy/get_protected_market_maker_count_onchain.py
@@ -1,0 +1,94 @@
+import asyncio
+import os
+import json
+
+from anchorpy import Wallet
+from dotenv import load_dotenv
+from solana.rpc.async_api import AsyncClient
+
+from driftpy.drift_client import DriftClient
+from driftpy.math.user_status import is_user_protected_maker
+from driftpy.types import UserAccount
+from driftpy.user_map.user_map import UserMap
+from driftpy.user_map.user_map_config import (
+    UserMapConfig,
+    WebsocketConfig as UserMapWebsocketConfig,
+)
+from solders.pubkey import Pubkey
+
+
+def to_serializable(obj):
+    """
+    Recursively converts an object to a JSON serializable format.
+    """
+    if isinstance(obj, Pubkey):
+        return str(obj)
+    if hasattr(obj, "__dict__"):
+        return {
+            key.strip("_"): to_serializable(value) for key, value in obj.__dict__.items()
+        }
+    elif isinstance(obj, list):
+        return [to_serializable(item) for item in obj]
+    elif isinstance(obj, bytes):
+        try:
+            return obj.decode("utf-8").strip("\x00")
+        except UnicodeDecodeError:
+            return str(obj)
+    # Add handling for other non-serializable types here if needed
+    return obj
+
+
+async def main():
+    load_dotenv()
+    url = os.getenv("RPC_URL")
+    if url is None:
+        raise ValueError("RPC_URL environment variable not set.")
+    connection = AsyncClient(url)
+
+    wallet = Wallet.dummy()  # Using a dummy wallet as we are only reading data
+
+    dc = DriftClient(
+        connection,
+        wallet,
+        "mainnet",  # Assuming mainnet, can be configured if needed
+    )
+    await dc.subscribe()
+
+    user_map = UserMap(UserMapConfig(dc, UserMapWebsocketConfig(), include_idle=True))
+    
+    print("Subscribing to UserMap... (this may take a moment)")
+    await user_map.subscribe()
+    print(f"UserMap subscribed. Found {len(user_map.user_map)} total users. Filtering for PMMs...")
+
+    try:
+        pmm_users = {}
+        for pubkey, user in user_map.user_map.items():
+            user_account = user.get_user_account()
+            if is_user_protected_maker(user_account):
+                pmm_users[pubkey] = to_serializable(user_account)
+
+        print(f"Found {len(pmm_users)} protected maker users.")
+
+        # Output the dictionary as a JSON string to the console
+        print(json.dumps(pmm_users, indent=4))
+
+        return pmm_users
+
+    except Exception as e:
+        print(f"An error occurred: {e}")
+        return None
+    finally:
+        await user_map.unsubscribe()
+        await dc.unsubscribe()
+        await connection.close()
+
+
+if __name__ == "__main__":
+    print("Attempting to fetch all protected market maker accounts using UserMap...")
+    pmm_accounts = asyncio.run(main())
+    if pmm_accounts is not None:
+        print(
+            f"Process finished. Found {len(pmm_accounts)} protected market maker accounts."
+        )
+    else:
+        print("Process finished with an error.") 

--- a/driftpy/get_protected_market_maker_count_usermap.py
+++ b/driftpy/get_protected_market_maker_count_usermap.py
@@ -5,7 +5,9 @@ from anchorpy import Wallet
 from dotenv import load_dotenv
 from solana.rpc.async_api import AsyncClient
 
+from driftpy.addresses import get_protected_maker_mode_config_public_key
 from driftpy.drift_client import DriftClient
+from driftpy.math.user_status import is_user_protected_maker
 from driftpy.user_map.user_map import UserMap
 from driftpy.user_map.user_map_config import UserMapConfig
 from driftpy.user_map.user_map_config import (
@@ -26,19 +28,18 @@ async def main():
     user = UserMap(UserMapConfig(dc, UserMapWebsocketConfig(), include_idle=True))
     await user.subscribe()
 
-    high_leverage_users = []
+    pmm_users = []
     keys = []
+    print(get_protected_maker_mode_config_public_key(dc.program_id))
     for key, user in user.user_map.items():
-        if user.is_high_leverage_mode():
-            high_leverage_users.append(user)
+        if is_user_protected_maker(user.get_user_account()):
+            pmm_users.append(user)
             keys.append(key)
-    return high_leverage_users, keys
+
+    return pmm_users, keys
 
 
 if __name__ == "__main__":
-    high_leverage_users, keys = asyncio.run(main())
+    pmm_users, keys = asyncio.run(main())
     keys.sort()
-    print(f"Number of high leverage users: {len(keys)}")
-    # with open("high_leverage_users.txt", "w") as f:
-    #     for key in keys:
-    #         f.write(f"{key}\n")
+    print(f"Number of protected maker users: {len(keys)}")

--- a/projects/2025/06/fuel-recon/README_fuel_scripts.md
+++ b/projects/2025/06/fuel-recon/README_fuel_scripts.md
@@ -1,0 +1,115 @@
+# Drift Fuel Export Scripts
+
+This directory contains two versions of scripts for exporting fuel data from Drift Protocol:
+
+1. `get_all_UserStats_fuelOnly.py` - Original version that reads directly from UserStats accounts
+2. `get_all_UserStats_fuelOnly_v2.py` - Enhanced version using `get_fuel_bonus()` method
+
+## Key Differences
+
+### Version 1 (Original)
+- Reads fuel data directly from UserStats account fields
+- Only captures **settled fuel** that's stored in the main UserStats account
+- May miss overflow fuel data when fuel amounts exceed field capacity
+- Faster but potentially incomplete
+
+### Version 2 (Enhanced with Overflow Support)
+- Uses the built-in `get_fuel_bonus()` method from DriftPy
+- Captures **both settled and overflow fuel** automatically
+- Handles edge cases where fuel amounts exceed UserStats field limits
+- More comprehensive but may be slower due to additional computations
+
+## Fuel Data Sources in Drift
+
+The fuel system in Drift has two main components:
+
+1. **Settled Fuel** - Stored directly in UserStats account fields
+   - `fuel_insurance`
+   - `fuel_deposits` 
+   - `fuel_borrows`
+   - `fuel_positions`
+   - `fuel_taker`
+   - `fuel_maker`
+
+2. **Overflow Fuel** - Handled through a separate FuelOverflow account when values exceed limits
+
+## Usage
+
+Both scripts support the same command-line arguments:
+
+```bash
+# Using default RPC and output file
+python get_all_UserStats_fuelOnly_v2.py
+
+# Using custom RPC URL
+python get_all_UserStats_fuelOnly_v2.py --rpc-url https://your-rpc-endpoint.com
+
+# Specifying output filename
+python get_all_UserStats_fuelOnly_v2.py --output my_fuel_export.csv
+
+# Enable verbose logging
+python get_all_UserStats_fuelOnly_v2.py --verbose
+```
+
+## Output Format
+
+Both scripts produce CSV files with the following columns:
+
+- `authority_address` - The wallet address that owns the account
+- `user_stats_address` - The derived UserStats account address
+- `fuel_insurance` - Insurance fuel points (decimal)
+- `fuel_deposits` - Deposit fuel points (decimal) 
+- `fuel_borrows` - Borrow fuel points (decimal)
+- `fuel_positions` - Position fuel points (decimal)
+- `fuel_taker` - Taker fuel points (decimal)
+- `fuel_maker` - Maker fuel points (decimal)
+- `last_fuel_update_ts` - Timestamp of last fuel update
+
+**Note**: Version 2 automatically converts raw fuel values to decimal by dividing by QUOTE_PRECISION.
+
+## Performance Considerations
+
+- Version 1 is faster as it only reads UserStats accounts
+- Version 2 may be slower as it:
+  - Creates DriftUser instances for each account
+  - Calculates unsettled fuel bonuses
+  - Checks for overflow accounts
+  
+## Recommendations
+
+- Use **Version 2** (`get_all_UserStats_fuelOnly_v2.py`) for:
+  - Complete fuel data including overflow
+  - Accuracy over speed
+  - Production reporting
+  
+- Use **Version 1** (`get_all_UserStats_fuelOnly.py`) for:
+  - Quick approximations
+  - When overflow fuel is not a concern
+  - Development/testing
+
+## Environment Setup
+
+Create a `.env` file with your RPC URL:
+
+```
+RPC_URL=https://your-solana-rpc-endpoint.com
+```
+
+Or pass it via command line:
+
+```bash
+python get_all_UserStats_fuelOnly_v2.py --rpc-url https://your-rpc-endpoint.com
+```
+
+## Dependencies
+
+Both scripts require:
+- driftpy
+- solders
+- anchorpy
+- python-dotenv
+
+Install with:
+```bash
+pip install driftpy solders anchorpy python-dotenv
+``` 

--- a/projects/2025/06/fuel-recon/compare-snapshots.py
+++ b/projects/2025/06/fuel-recon/compare-snapshots.py
@@ -1,0 +1,136 @@
+import pandas as pd
+import numpy as np
+from datetime import datetime
+
+def compare_snapshots():
+    """
+    Compares total fuel for each authority from two different snapshots and generates a report.
+    """
+    # Define file paths relative to the script location
+    file1_path = 'complete_snapshot.csv'
+    # The excel file is in the root of the project
+    file2_path = '06122025140049_user_stats_fuel_export.csv'
+    
+    # Generate timestamp for the output file
+    timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
+    output_path = f'comparison_report_{timestamp}.csv'
+
+    # --- Load Data ---
+    try:
+        df1 = pd.read_csv(file1_path)
+        df2 = pd.read_csv(file2_path)
+    except FileNotFoundError as e:
+        print(f"Error loading files: {e}")
+        print("Please ensure 'complete_snapshot.csv' is in the same directory as the script,")
+        print("and '06122025140049_user_stats_fuel_export.xlsx' is in the project root.")
+        return
+
+    # --- Data Preparation ---
+
+    # Prepare DataFrame 1
+    # Sanitize column headers to remove any leading/trailing whitespace
+    df1.columns = df1.columns.str.strip()
+
+    # Create new, clean boolean columns for filtering, leaving original data intact.
+    bool_cols = ['isDriftUser', 'isVaultDepositor', 'isVaultManager']
+    for col in bool_cols:
+        new_col_name = f"{col}_bool"
+        # Convert to a lowercase string, strip whitespace, and check for exact equality with 'true'.
+        df1[new_col_name] = df1[col].astype(str).str.strip().str.lower() == 'true'
+
+    # --- Identify Authorities to Exclude from Both Files ---
+    # An authority should be excluded if it fails any of the required conditions.
+    exclusion_mask = (df1['isDriftUser_bool'] == False) | (df1['isVaultDepositor_bool'] == True) | (df1['isVaultManager_bool'] == True)
+    authorities_to_exclude = set(df1[exclusion_mask]['authority'])
+
+    # --- Generate Exclusion Report (based on initial state of complete_snapshot.csv) ---
+    total_records_initial = len(df1)
+    excluded_not_drift_user = (df1['isDriftUser_bool'] == False).sum()
+    excluded_is_vault_depositor = (df1['isVaultDepositor_bool'] == True).sum()
+    excluded_is_vault_manager = (df1['isVaultManager_bool'] == True).sum()
+    total_unique_authorities_excluded = len(authorities_to_exclude)
+
+    print("--- Exclusion Report from 'complete_snapshot.csv' ---")
+    print(f"Initial total authorities in complete_snapshot: {total_records_initial}")
+    print(f"Authorities flagged for exclusion because isDriftUser is FALSE: {excluded_not_drift_user}")
+    print(f"Authorities flagged for exclusion because isVaultDepositor is TRUE: {excluded_is_vault_depositor}")
+    print(f"Authorities flagged for exclusion because isVaultManager is TRUE: {excluded_is_vault_manager}")
+    print(f"Total unique authorities to be excluded from both files: {total_unique_authorities_excluded}")
+    print("-" * 35)
+
+    # --- Apply Exclusion to BOTH DataFrames ---
+    initial_df1_count = len(df1)
+    initial_df2_count = len(df2)
+
+    df1 = df1[~df1['authority'].isin(authorities_to_exclude)]
+    df2 = df2[~df2['authority'].isin(authorities_to_exclude)]
+
+    print("--- Data Filtering Summary ---")
+    print(f"Excluded {initial_df1_count - len(df1)} records from '{file1_path}'")
+    print(f"Excluded {initial_df2_count - len(df2)} records from '{file2_path}'")
+    print(f"Authorities remaining in '{file1_path}' for comparison: {len(df1)}")
+    print(f"Authorities remaining in '{file2_path}' for comparison: {len(df2)}")
+    print("-" * 35)
+
+
+    # --- Data Preparation (on already filtered data) ---
+    # Prepare DataFrame 1
+    df1_snap = df1[['authority', 'totalFuel']].copy()
+    df1_snap.rename(columns={'totalFuel': 'balance_snapshot'}, inplace=True)
+    df1_snap.set_index('authority', inplace=True)
+
+
+    # Prepare DataFrame 2
+    # The new CSV has 'authority' and 'totalFuel' columns directly.
+    df2.columns = df2.columns.str.strip() # Sanitize headers
+    df2_export = df2[['authority', 'totalFuel']].copy()
+    df2_export.rename(columns={'totalFuel': 'balance_export'}, inplace=True)
+    df2_export.set_index('authority', inplace=True)
+
+
+    # --- Merge DataFrames ---
+    comparison_df = pd.merge(df1_snap, df2_export, on='authority', how='outer')
+    comparison_df.fillna(0, inplace=True) # Fill missing values with 0
+
+    # --- Calculate Difference ---
+    comparison_df['difference'] = comparison_df['balance_snapshot'] - comparison_df['balance_export']
+
+    # --- Generate Report ---
+    total_auth_snap = len(df1_snap)
+    total_auth_export = len(df2_export)
+
+    in_snap_only = comparison_df['balance_export'] == 0
+    in_export_only = comparison_df['balance_snapshot'] == 0
+    
+    in_both = (~in_snap_only) & (~in_export_only)
+
+    num_in_snap_only = in_snap_only.sum()
+    num_in_export_only = in_export_only.sum()
+    num_in_both = in_both.sum()
+
+    # Mismatched balances for authorities present in both files
+    mismatched = comparison_df[in_both & (comparison_df['difference'] != 0)]
+    num_mismatched = len(mismatched)
+
+    print("--- Fuel Snapshot Comparison Report ---")
+    print(f"Total authorities in final comparison from '{file1_path}': {total_auth_snap}")
+    print(f"Total authorities in final comparison from '{file2_path}': {total_auth_export}")
+    print("-" * 35)
+    print(f"Authorities present in both files (post-filtering): {num_in_both}")
+    print(f"Authorities with mismatched balances: {num_mismatched}")
+    print(f"Authorities only in '{file1_path}' (post-filtering): {num_in_snap_only}")
+    print(f"Authorities only in '{file2_path}' (post-filtering): {num_in_export_only}")
+    print("-" * 35)
+
+    # --- Output CSV ---
+    comparison_df.reset_index(inplace=True)
+    comparison_df.rename(columns={
+        'balance_snapshot': 'balance_from_complete_snapshot',
+        'balance_export': 'balance_from_fuel_export'
+    }, inplace=True)
+    
+    comparison_df.to_csv(output_path, index=False)
+    print(f"Comparison details saved to '{output_path}'")
+
+if __name__ == '__main__':
+    compare_snapshots()

--- a/projects/2025/06/fuel-recon/get_all_UserStats_fuelOnly.py
+++ b/projects/2025/06/fuel-recon/get_all_UserStats_fuelOnly.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+
+import argparse
+import asyncio
+import os
+import csv
+import logging
+from datetime import datetime
+import base58
+
+from solders.keypair import Keypair # type: ignore
+from solders.pubkey import Pubkey # type: ignore
+from anchorpy import Wallet
+from driftpy.drift_client import DriftClient
+from driftpy.account_subscription_config import AccountSubscriptionConfig
+# Removed: from driftpy.user_map.userstats_map import UserStatsMap
+# Removed: from driftpy.user_map.user_map_config import UserStatsMapConfig
+# from driftpy.addresses import get_user_stats_account_public_key # We will define this locally
+from solana.rpc.async_api import AsyncClient
+from dotenv import load_dotenv
+
+# Removed local get_user_stats_account_public_key as we are not deriving it anymore
+
+def flatten_user_stats_to_row(authority_pk_str, user_stats_pk_str, user_stats_data) -> list:
+    """
+    Extract only fuel-related UserStats data into a list for CSV row.
+    Returns only fuel-specific fields.
+    """
+    if not user_stats_data:
+        return None
+    
+    # Extract only fuel-related fields
+    row = [
+        str(authority_pk_str),  # Authority address (from UserStats account)
+        str(user_stats_pk_str),  # UserStats account address
+        getattr(user_stats_data, 'fuel_insurance', 0),
+        getattr(user_stats_data, 'fuel_deposits', 0),
+        getattr(user_stats_data, 'fuel_borrows', 0),
+        getattr(user_stats_data, 'fuel_positions', 0),
+        getattr(user_stats_data, 'fuel_taker', 0),
+        getattr(user_stats_data, 'fuel_maker', 0),
+        getattr(user_stats_data, 'last_fuel_if_bonus_update_ts', 0),
+    ]
+    
+    return row
+
+
+def should_include_record(row):
+    """
+    Check if a record should be included based on fuel values.
+    Returns True if at least one fuel metric (excluding timestamp) is non-zero.
+    """
+    # Check fuel values (indices 2-7, excluding the timestamp at index 8)
+    fuel_values = row[2:8]  # fuel_insurance through fuel_maker
+    return any(value != 0 for value in fuel_values)
+
+
+def get_csv_headers():
+    """
+    Get CSV column headers for fuel-specific fields only.
+    """
+    headers = [
+        "authority_address",
+        "user_stats_address",
+        "fuel_insurance",
+        "fuel_deposits",
+        "fuel_borrows",
+        "fuel_positions",
+        "fuel_taker",
+        "fuel_maker",
+        "last_fuel_if_bonus_update_ts",
+    ]
+    
+    return headers
+
+
+async def main():
+    parser = argparse.ArgumentParser(description="Export fuel-related UserStats data to CSV.")
+    
+    # Generate timestamp for the default filename
+    timestamp = datetime.now().strftime("%m%d%Y%H%M%S")
+    default_filename = f"{timestamp}_user_stats_fuel_export.csv"
+
+    DEFAULT_RPC_URL = "https://api.mainnet-beta.solana.com"
+    load_dotenv()
+    rpc_url = os.getenv("RPC_URL", DEFAULT_RPC_URL)
+    parser.add_argument("--rpc-url", type=str, default=rpc_url, help=f"The Solana RPC URL (default: {rpc_url} or RPC_URL from .env).")
+    parser.add_argument("--output", type=str, default=default_filename, help=f"Output CSV filename (default: {default_filename})")
+    parser.add_argument("--verbose", action="store_true", help="Enable verbose output")
+
+    args = parser.parse_args()
+
+    # Configure logging
+    log_level = logging.DEBUG if args.verbose else logging.INFO
+    logging.basicConfig(
+        level=log_level, 
+        format='%(asctime)s - %(levelname)s - %(message)s',
+        datefmt='%Y-%m-%d %H:%M:%S'
+    )
+
+    logging.info("🚀 Starting fuel stats export script...")
+    logging.debug(f"Script arguments: {args}")
+
+    connection = AsyncClient(args.rpc_url)
+    logging.info(f"🔌 Connecting to RPC endpoint: {args.rpc_url}")
+    # Use a dummy wallet as we are only reading data
+    wallet = Wallet(Keypair()) 
+    drift_client = DriftClient(
+        connection,
+        wallet,
+        "mainnet", # Ensure this is the desired environment or make it configurable
+        account_subscription=AccountSubscriptionConfig("cached")
+    )
+    
+    # The size of the UserStats account struct on-chain
+    USER_STATS_ACCOUNT_SIZE = 488
+
+    try:
+        logging.debug("Subscribing to Drift client...")
+        await drift_client.subscribe()
+        logging.info("Successfully subscribed to Drift client.")
+        
+        logging.info("Fetching all UserStats accounts... This may take a while.")
+
+        # More efficient approach:
+        # 1. Get all UserStats account pubkeys using getProgramAccounts with a dataSlice to be lightweight.
+        # 2. Paginate through the pubkeys and fetch account data in batches using getMultipleAccounts.
+
+        # Step 1: Get all UserStats account pubkeys
+        logging.info("Fetching all UserStats account public keys...")
+        
+        # Get the discriminator for the UserStats account
+        user_stats_discriminator = drift_client.program.account['UserStats']._coder.discriminator
+        
+        # Fetch accounts with matching discriminator and size, but only get their pubkeys.
+        gpa_resp = await connection.get_program_accounts(
+            drift_client.program_id,
+            encoding="base64",
+            filters=[
+                {"dataSize": USER_STATS_ACCOUNT_SIZE},
+                {"memcmp": {"offset": 0, "bytes": base58.b58encode(user_stats_discriminator).decode('utf-8')}}
+            ],
+            data_slice={"offset": 0, "length": 0}
+        )
+        
+        user_stats_pubkeys = [acc["pubkey"] for acc in gpa_resp]
+        logging.info(f"👥 Found {len(user_stats_pubkeys)} UserStats accounts. Now processing in batches.")
+        
+        with open(args.output, 'w', newline='') as csvfile:
+            writer = csv.writer(csvfile)
+            logging.info(f"📄 Opened output file for writing: {args.output}")
+            
+            headers = get_csv_headers()
+            writer.writerow(headers)
+            logging.debug(f"Wrote CSV headers: {headers}")
+            
+            count = 0
+            skipped_count = 0
+            
+            # Step 2: Process pubkeys in batches
+            batch_size = 100
+            total_batches = (len(user_stats_pubkeys) + batch_size - 1) // batch_size
+            logging.info(f"⚙️ Starting processing of {len(user_stats_pubkeys)} accounts in {total_batches} batches of size {batch_size}...")
+
+            for i in range(0, len(user_stats_pubkeys), batch_size):
+                batch_pubkeys = user_stats_pubkeys[i:i+batch_size]
+                logging.debug(f"Processing batch {i//batch_size + 1}/{total_batches}")
+                
+                try:
+                    # Get account data for the current batch
+                    accounts_data = await connection.get_multiple_accounts(batch_pubkeys)
+                    
+                    for j, acc_data in enumerate(accounts_data):
+                        if acc_data is None:
+                            logging.debug(f"Could not fetch account data for {batch_pubkeys[j]}. Skipping.")
+                            continue
+
+                        user_stats_pk = batch_pubkeys[j]
+                        
+                        try:
+                            # Decode the account data to get UserStats object
+                            user_stats_data = drift_client.program.coder.accounts.decode(acc_data.data)
+                            authority_pk = user_stats_data.authority
+
+                            logging.debug(f"Processing UserStats account {user_stats_pk} for authority {authority_pk}")
+
+                            # Create row data with fuel fields only
+                            row = flatten_user_stats_to_row(
+                                str(authority_pk), 
+                                str(user_stats_pk),
+                                user_stats_data
+                            )
+                            
+                            if not row:
+                                logging.debug(f"Flattening row returned None for {user_stats_pk}, skipping.")
+                                continue
+                            
+                            # Check if this record has any non-zero fuel values
+                            if not should_include_record(row):
+                                skipped_count += 1
+                                logging.debug(f"Record for {authority_pk} has zero fuel values. Skipping. Total skipped: {skipped_count}")
+                                continue
+                            
+                            # Write to CSV
+                            writer.writerow(row)
+                            
+                            count += 1
+                        except Exception as e:
+                            logging.warning(f"Failed to decode or process UserStats account {user_stats_pk}: {e}")
+                            continue
+
+                    if (i//batch_size + 1) % 10 == 0:
+                        logging.info(f"  ...processed batch {i//batch_size + 1}/{total_batches}, exported {count} accounts so far...")
+
+                except Exception as e:
+                    logging.error(f"Error processing batch {i//batch_size + 1}: {e}")
+                    continue
+        
+        logging.info("\n✅ Fuel data export complete!")
+        logging.info(f"Total UserStats accounts with fuel data exported: {count}")
+        logging.info(f"Total accounts skipped (zero fuel values): {skipped_count}")
+        logging.info(f"Output saved to: {args.output}")
+
+    except Exception as e:
+        logging.exception(f"An unhandled error occurred: {e}")
+    finally:
+        logging.info("Cleaning up resources...")
+        await drift_client.unsubscribe()
+        await connection.close()
+        logging.info("Cleanup complete. Script finished.")
+
+
+if __name__ == "__main__":
+    asyncio.run(main()) 

--- a/projects/2025/06/fuel-recon/get_all_UserStats_fuelOnly_v2.py
+++ b/projects/2025/06/fuel-recon/get_all_UserStats_fuelOnly_v2.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+
+import argparse
+import asyncio
+import os
+import csv
+import logging
+import time
+from datetime import datetime
+
+from solders.keypair import Keypair # type: ignore
+from solders.pubkey import Pubkey # type: ignore
+from anchorpy import Wallet
+from driftpy.drift_client import DriftClient
+from driftpy.account_subscription_config import AccountSubscriptionConfig
+from driftpy.drift_user import DriftUser
+from driftpy.constants.numeric_constants import QUOTE_PRECISION
+# from driftpy.addresses import get_user_stats_account_public_key # We will define this locally
+from solana.rpc.async_api import AsyncClient
+from dotenv import load_dotenv
+
+# Added helper function from get_UserStats.py
+def get_user_stats_account_public_key(authority: Pubkey, program_id: Pubkey) -> Pubkey:
+    """
+    Derives the userStats account public key for a given authority.
+    """
+    user_stats_account_pk, _ = Pubkey.find_program_address(
+        [b'user_stats', bytes(authority)],
+        program_id
+    )
+    return user_stats_account_pk
+
+
+def flatten_fuel_bonus_to_row(authority_pk_str, user_stats_pk_str, fuel_bonus_data, last_update_ts) -> list:
+    """
+    Extract fuel bonus data into a list for CSV row.
+    The fuel_bonus_data is a dictionary returned by get_fuel_bonus() method.
+    """
+    if not fuel_bonus_data:
+        return None
+    
+    # Convert raw fuel values to decimal by dividing by QUOTE_PRECISION
+    row = [
+        str(authority_pk_str),  # Authority address (from User account)
+        str(user_stats_pk_str),  # UserStats account address
+        fuel_bonus_data.get('insurance_fuel', 0) / QUOTE_PRECISION,
+        fuel_bonus_data.get('deposit_fuel', 0) / QUOTE_PRECISION,
+        fuel_bonus_data.get('borrow_fuel', 0) / QUOTE_PRECISION,
+        fuel_bonus_data.get('position_fuel', 0) / QUOTE_PRECISION,
+        fuel_bonus_data.get('taker_fuel', 0) / QUOTE_PRECISION,
+        fuel_bonus_data.get('maker_fuel', 0) / QUOTE_PRECISION,
+        last_update_ts,  # Last fuel update timestamp
+    ]
+    
+    return row
+
+
+def should_include_record(row):
+    """
+    Check if a record should be included based on fuel values.
+    Returns True if at least one fuel metric (excluding timestamp) is non-zero.
+    """
+    # Check fuel values (indices 2-7, excluding the timestamp at index 8)
+    fuel_values = row[2:8]  # fuel_insurance through fuel_maker
+    return any(value != 0 for value in fuel_values)
+
+
+def get_csv_headers():
+    """
+    Get CSV column headers for fuel fields.
+    """
+    headers = [
+        "authority_address",
+        "user_stats_address",
+        "fuel_insurance",
+        "fuel_deposits",
+        "fuel_borrows",
+        "fuel_positions",
+        "fuel_taker",
+        "fuel_maker",
+        "last_fuel_update_ts",
+    ]
+    
+    return headers
+
+
+async def main():
+    parser = argparse.ArgumentParser(description="Export fuel data (including overflow) to CSV using get_fuel_bonus().")
+    
+    # Generate timestamp for the default filename
+    timestamp = datetime.now().strftime("%m%d%Y%H%M%S")
+    default_filename = f"{timestamp}_user_stats_fuel_v2_export.csv"
+
+    DEFAULT_RPC_URL = "https://api.mainnet-beta.solana.com"
+    load_dotenv()
+    rpc_url = os.getenv("RPC_URL", DEFAULT_RPC_URL)
+    parser.add_argument("--rpc-url", type=str, default=rpc_url, help=f"The Solana RPC URL (default: {rpc_url} or RPC_URL from .env).")
+    parser.add_argument("--output", type=str, default=default_filename, help=f"Output CSV filename (default: {default_filename})")
+    parser.add_argument("--verbose", action="store_true", help="Enable verbose output")
+
+    args = parser.parse_args()
+
+    # Configure logging
+    log_level = logging.DEBUG if args.verbose else logging.INFO
+    logging.basicConfig(
+        level=log_level, 
+        format='%(asctime)s - %(levelname)s - %(message)s',
+        datefmt='%Y-%m-%d %H:%M:%S'
+    )
+
+    logging.info("🚀 Starting fuel stats export script (v2 with overflow support)...")
+    logging.debug(f"Script arguments: {args}")
+
+    connection = AsyncClient(args.rpc_url)
+    logging.info(f"🔌 Connecting to RPC endpoint: {args.rpc_url}")
+    # Use a dummy wallet as we are only reading data
+    wallet = Wallet(Keypair()) 
+    drift_client = DriftClient(
+        connection,
+        wallet,
+        "mainnet", # Ensure this is the desired environment or make it configurable
+        account_subscription=AccountSubscriptionConfig("cached")
+    )
+
+    try:
+        logging.debug("Subscribing to Drift client...")
+        await drift_client.subscribe()
+        logging.info("✅ Successfully subscribed to Drift client.")
+        
+        logging.info("⏳ Fetching all User accounts to extract fuel statistics... This may take a while.")
+        
+        all_user_account_wrappers = await drift_client.program.account["User"].all()
+        
+        logging.info(f"👥 Found {len(all_user_account_wrappers)} User accounts. Now processing fuel data with overflow support.")
+        
+        with open(args.output, 'w', newline='') as csvfile:
+            writer = csv.writer(csvfile)
+            logging.info(f"📄 Opened output file for writing: {args.output}")
+            
+            headers = get_csv_headers()
+            writer.writerow(headers)
+            logging.debug(f"Wrote CSV headers: {headers}")
+            
+            # Counters for progress
+            count = 0
+            skipped_count = 0
+            error_count = 0
+            processed_authorities = set() # To avoid processing duplicate authorities if User accounts share one
+            
+            # Get current timestamp for fuel bonus calculation
+            current_timestamp = int(time.time())
+            
+            total_wrappers = len(all_user_account_wrappers)
+            logging.info(f"⚙️ Starting processing of {total_wrappers} user account wrappers...")
+            
+            for i, user_account_wrapper in enumerate(all_user_account_wrappers):
+                user_data = user_account_wrapper.account
+                authority_pk = user_data.authority
+
+                logging.debug(f"Processing wrapper {i+1}/{total_wrappers}: authority={authority_pk}")
+
+                if str(authority_pk) in processed_authorities:
+                    logging.debug(f"Authority {authority_pk} already processed. Skipping.")
+                    continue
+                
+                processed_authorities.add(str(authority_pk))
+
+                try:
+                    # Derive UserStats account public key
+                    user_stats_account_pk = get_user_stats_account_public_key(authority_pk, drift_client.program_id)
+                    logging.debug(f"Derived UserStats PK for authority {authority_pk}: {user_stats_account_pk}")
+                    
+                    # Create a DriftUser instance for this user
+                    # We pass the sub_account_id from the user data
+                    drift_user = DriftUser(
+                        drift_client,
+                        user_public_key=authority_pk,
+                        sub_account_id=user_data.sub_account_id,
+                        use_cache=False  # Don't cache since we're processing many users
+                    )
+                    
+                    # The DriftUser might need to load the user account data
+                    # Call get_fuel_bonus which handles both settled and overflow fuel
+                    try:
+                        fuel_bonus_data = await drift_user.get_fuel_bonus(
+                            now=current_timestamp,
+                            include_settled=True,    # Include fuel from user_stats
+                            include_unsettled=True   # Include calculated overflow fuel
+                        )
+                    except Exception as fuel_error:
+                        logging.debug(f"Could not get fuel bonus for authority {authority_pk}: {fuel_error}")
+                        error_count += 1
+                        continue
+                    
+                    if not fuel_bonus_data:
+                        logging.debug(f"No fuel bonus data returned for authority {authority_pk}. Skipping.")
+                        continue
+                    
+                    logging.debug(f"Successfully fetched fuel bonus data for {authority_pk}: {fuel_bonus_data}")
+                    
+                    # Get the last fuel update timestamp from user account
+                    last_fuel_update_ts = getattr(user_data, 'last_fuel_bonus_update_ts', 0)
+
+                    # Create row data with all fuel types
+                    row = flatten_fuel_bonus_to_row(
+                        str(authority_pk), 
+                        str(user_stats_account_pk),
+                        fuel_bonus_data,
+                        last_fuel_update_ts
+                    )
+                    
+                    if not row:
+                        logging.debug(f"Flattening row returned None for {user_stats_account_pk}, skipping.")
+                        continue
+                    
+                    # Check if this record has any non-zero fuel values
+                    if not should_include_record(row):
+                        skipped_count += 1
+                        logging.debug(f"Record for {authority_pk} has zero fuel values. Skipping. Total skipped: {skipped_count}")
+                        continue
+                    
+                    # Write to CSV
+                    writer.writerow(row)
+                    logging.debug(f"Wrote record for authority {authority_pk} to CSV.")
+                    
+                    count += 1
+                    if count > 0 and count % 100 == 0:
+                        logging.info(f"  ...exported {count} accounts with fuel data so far...")
+                        
+                except Exception as e:
+                    # Log the error but continue processing
+                    logging.debug(f"Could not process authority {authority_pk}: {e}")
+                    error_count += 1
+                    continue
+        
+        logging.info("\n✅ Fuel data export complete!")
+        logging.info(f"📊 Total accounts with fuel data exported: {count}")
+        logging.info(f"⏭️  Total accounts skipped (zero fuel values): {skipped_count}")
+        logging.info(f"❌ Total accounts with errors: {error_count}")
+        logging.info(f"💾 Output saved to: {args.output}")
+        logging.info("📝 Note: This version includes both settled fuel and overflow fuel automatically.")
+
+    except Exception as e:
+        logging.exception(f"An unhandled error occurred: {e}")
+    finally:
+        logging.info("🧹 Cleaning up resources...")
+        await drift_client.unsubscribe()
+        await connection.close()
+        logging.info("✨ Cleanup complete. Script finished.")
+
+
+if __name__ == "__main__":
+    asyncio.run(main()) 

--- a/projects/2025/06/fuel-recon/get_all_UserStats_fuelOnly_v3.py
+++ b/projects/2025/06/fuel-recon/get_all_UserStats_fuelOnly_v3.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+
+import argparse
+import asyncio
+import os
+import csv
+import logging
+from datetime import datetime
+import base58
+import hashlib
+
+from solders.keypair import Keypair # type: ignore
+from solders.pubkey import Pubkey # type: ignore
+from anchorpy import Wallet
+from anchorpy.coder.accounts import _account_discriminator
+from driftpy.drift_client import DriftClient
+from driftpy.account_subscription_config import AccountSubscriptionConfig
+# Removed: from driftpy.user_map.userstats_map import UserStatsMap
+# Removed: from driftpy.user_map.user_map_config import UserStatsMapConfig
+# from driftpy.addresses import get_user_stats_account_public_key # We will define this locally
+from solana.rpc.async_api import AsyncClient
+from solana.rpc.types import DataSliceOpts, MemcmpOpts, DataSizeOpts
+from dotenv import load_dotenv
+
+# Removed local get_user_stats_account_public_key as we are not deriving it anymore
+
+def flatten_user_stats_to_row(authority_pk_str, user_stats_pk_str, user_stats_data) -> list:
+    """
+    Extract only fuel-related UserStats data into a list for CSV row.
+    Returns only fuel-specific fields.
+    """
+    if not user_stats_data:
+        return None
+    
+    # Extract only fuel-related fields
+    row = [
+        str(authority_pk_str),  # Authority address (from UserStats account)
+        str(user_stats_pk_str),  # UserStats account address
+        getattr(user_stats_data, 'fuel_insurance', 0),
+        getattr(user_stats_data, 'fuel_deposits', 0),
+        getattr(user_stats_data, 'fuel_borrows', 0),
+        getattr(user_stats_data, 'fuel_positions', 0),
+        getattr(user_stats_data, 'fuel_taker', 0),
+        getattr(user_stats_data, 'fuel_maker', 0),
+        getattr(user_stats_data, 'last_fuel_if_bonus_update_ts', 0),
+    ]
+    
+    return row
+
+
+def should_include_record(row):
+    """
+    Check if a record should be included based on fuel values.
+    Returns True if at least one fuel metric (excluding timestamp) is non-zero.
+    """
+    # Check fuel values (indices 2-7, excluding the timestamp at index 8)
+    fuel_values = row[2:8]  # fuel_insurance through fuel_maker
+    return any(value != 0 for value in fuel_values)
+
+
+def get_csv_headers():
+    """
+    Get CSV column headers for fuel-specific fields only.
+    """
+    headers = [
+        "authority_address",
+        "user_stats_address",
+        "fuel_insurance",
+        "fuel_deposits",
+        "fuel_borrows",
+        "fuel_positions",
+        "fuel_taker",
+        "fuel_maker",
+        "last_fuel_if_bonus_update_ts",
+    ]
+    
+    return headers
+
+
+async def main():
+    parser = argparse.ArgumentParser(description="Export fuel-related UserStats data to CSV.")
+    
+    # Generate timestamp for the default filename
+    timestamp = datetime.now().strftime("%m%d%Y%H%M%S")
+    default_filename = f"{timestamp}_user_stats_fuel_export.csv"
+
+    DEFAULT_RPC_URL = "https://api.mainnet-beta.solana.com"
+    load_dotenv()
+    rpc_url = os.getenv("RPC_URL", DEFAULT_RPC_URL)
+    parser.add_argument("--rpc-url", type=str, default=rpc_url, help=f"The Solana RPC URL (default: {rpc_url} or RPC_URL from .env).")
+    parser.add_argument("--output", type=str, default=default_filename, help=f"Output CSV filename (default: {default_filename})")
+    parser.add_argument("--verbose", action="store_true", help="Enable verbose output")
+
+    args = parser.parse_args()
+
+    # Configure logging
+    log_level = logging.DEBUG if args.verbose else logging.INFO
+    logging.basicConfig(
+        level=log_level, 
+        format='%(asctime)s - %(levelname)s - %(message)s',
+        datefmt='%Y-%m-%d %H:%M:%S'
+    )
+
+    logging.info("🚀 Starting fuel stats export script...")
+    logging.debug(f"Script arguments: {args}")
+
+    connection = AsyncClient(args.rpc_url)
+    logging.info(f"🔌 Connecting to RPC endpoint: {args.rpc_url}")
+    # Use a dummy wallet as we are only reading data
+    wallet = Wallet(Keypair()) 
+    drift_client = DriftClient(
+        connection,
+        wallet,
+        "mainnet", # Ensure this is the desired environment or make it configurable
+        account_subscription=AccountSubscriptionConfig("cached")
+    )
+    
+    # The size of the UserStats account struct on-chain
+    USER_STATS_ACCOUNT_SIZE = 488
+
+    try:
+        logging.debug("Subscribing to Drift client...")
+        await drift_client.subscribe()
+        logging.info("Successfully subscribed to Drift client.")
+        
+        logging.info("Fetching all UserStats accounts... This may take a while.")
+
+        # More efficient approach:
+        # 1. Get all UserStats account pubkeys using getProgramAccounts with a dataSlice to be lightweight.
+        # 2. Paginate through the pubkeys and fetch account data in batches using getMultipleAccounts.
+
+        # Step 1: Get all UserStats account pubkeys
+        logging.info("Fetching all UserStats account public keys...")
+        
+        # The correct, driftpy-idiomatic way to get the discriminator
+        user_stats_discriminator = _account_discriminator("UserStats")
+        
+        # Fetch accounts with matching discriminator and size, but only get their pubkeys.
+        gpa_resp = await connection.get_program_accounts(
+            drift_client.program_id,
+            encoding="base64",
+            filters=[
+                DataSizeOpts(USER_STATS_ACCOUNT_SIZE),
+                MemcmpOpts(offset=0, bytes=base58.b58encode(user_stats_discriminator).decode('utf-8'))
+            ],
+            data_slice=DataSliceOpts(offset=0, length=0)
+        )
+        
+        user_stats_pubkeys = [Pubkey.from_string(acc["pubkey"]) for acc in gpa_resp]
+        logging.info(f"👥 Found {len(user_stats_pubkeys)} UserStats accounts. Now processing in batches.")
+        
+        with open(args.output, 'w', newline='') as csvfile:
+            writer = csv.writer(csvfile)
+            logging.info(f"📄 Opened output file for writing: {args.output}")
+            
+            headers = get_csv_headers()
+            writer.writerow(headers)
+            logging.debug(f"Wrote CSV headers: {headers}")
+            
+            count = 0
+            skipped_count = 0
+            
+            # Step 2: Process pubkeys in batches
+            batch_size = 100
+            total_batches = (len(user_stats_pubkeys) + batch_size - 1) // batch_size
+            logging.info(f"⚙️ Starting processing of {len(user_stats_pubkeys)} accounts in {total_batches} batches of size {batch_size}...")
+
+            for i in range(0, len(user_stats_pubkeys), batch_size):
+                batch_pubkeys = user_stats_pubkeys[i:i+batch_size]
+                logging.debug(f"Processing batch {i//batch_size + 1}/{total_batches}")
+                
+                try:
+                    # Get account data for the current batch
+                    accounts_data = await connection.get_multiple_accounts(batch_pubkeys)
+                    
+                    for j, acc_data in enumerate(accounts_data):
+                        if acc_data is None:
+                            logging.debug(f"Could not fetch account data for {batch_pubkeys[j]}. Skipping.")
+                            continue
+
+                        user_stats_pk = batch_pubkeys[j]
+                        
+                        try:
+                            # Decode the account data to get UserStats object
+                            user_stats_data = drift_client.program.coder.accounts.decode(acc_data.data)
+                            authority_pk = user_stats_data.authority
+
+                            logging.debug(f"Processing UserStats account {user_stats_pk} for authority {authority_pk}")
+
+                            # Create row data with fuel fields only
+                            row = flatten_user_stats_to_row(
+                                str(authority_pk), 
+                                str(user_stats_pk),
+                                user_stats_data
+                            )
+                            
+                            if not row:
+                                logging.debug(f"Flattening row returned None for {user_stats_pk}, skipping.")
+                                continue
+                            
+                            # Check if this record has any non-zero fuel values
+                            if not should_include_record(row):
+                                skipped_count += 1
+                                logging.debug(f"Record for {authority_pk} has zero fuel values. Skipping. Total skipped: {skipped_count}")
+                                continue
+                            
+                            # Write to CSV
+                            writer.writerow(row)
+                            
+                            count += 1
+                        except Exception as e:
+                            logging.warning(f"Failed to decode or process UserStats account {user_stats_pk}: {e}")
+                            continue
+
+                    if (i//batch_size + 1) % 10 == 0:
+                        logging.info(f"  ...processed batch {i//batch_size + 1}/{total_batches}, exported {count} accounts so far...")
+
+                except Exception as e:
+                    logging.error(f"Error processing batch {i//batch_size + 1}: {e}")
+                    continue
+        
+        logging.info("\n✅ Fuel data export complete!")
+        logging.info(f"Total UserStats accounts with fuel data exported: {count}")
+        logging.info(f"Total accounts skipped (zero fuel values): {skipped_count}")
+        logging.info(f"Output saved to: {args.output}")
+
+    except Exception as e:
+        logging.exception(f"An unhandled error occurred: {e}")
+    finally:
+        logging.info("Cleaning up resources...")
+        await drift_client.unsubscribe()
+        await connection.close()
+        logging.info("Cleanup complete. Script finished.")
+
+
+if __name__ == "__main__":
+    asyncio.run(main()) 

--- a/projects/2025/06/fuel-recon/get_all_UserStats_v4.py
+++ b/projects/2025/06/fuel-recon/get_all_UserStats_v4.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python3
+"""
+Production script to export all Drift Protocol UserStats accounts to CSV.
+"""
+
+import argparse
+import asyncio
+import csv
+import logging
+import os
+from datetime import datetime
+
+from anchorpy import Wallet
+from driftpy.account_subscription_config import AccountSubscriptionConfig
+from driftpy.drift_client import DriftClient
+from driftpy.user_map.user_map_config import UserStatsMapConfig, SyncConfig
+from driftpy.user_map.userstats_map import UserStatsMap
+from dotenv import load_dotenv
+from solana.rpc.async_api import AsyncClient
+from solders.keypair import Keypair
+
+# Configure logging
+logger = logging.getLogger(__name__)
+
+
+class UserStatsExporter:
+    def __init__(self, rpc_url: str, output_file: str):
+        self.rpc_url = rpc_url
+        self.output_file = output_file
+        self.connection = AsyncClient(rpc_url)
+        self.drift_client = None
+        self.user_stats_map = None
+
+    async def initialize_drift_client(self):
+        """Initialize DriftClient with minimal configuration for read-only operations."""
+        dummy_keypair = Keypair()
+        wallet = Wallet(dummy_keypair)
+
+        self.drift_client = DriftClient(
+            self.connection,
+            wallet,
+            "mainnet",
+            account_subscription=AccountSubscriptionConfig("cached"),
+        )
+
+        await self.drift_client.subscribe()
+        logger.info("DriftClient initialized successfully")
+
+    async def initialize_user_stats_map(self, use_paginated: bool = True):
+        """Initialize UserStatsMap with optimal configuration."""
+        sync_config = SyncConfig(
+            type="paginated" if use_paginated else "default",
+            chunk_size=100,
+            concurrency_limit=10,
+        )
+
+        config = UserStatsMapConfig(
+            drift_client=self.drift_client,
+            connection=self.connection,
+            sync_config=sync_config,
+        )
+
+        self.user_stats_map = UserStatsMap(config)
+        logger.info(
+            f"UserStatsMap initialized with {'paginated' if use_paginated else 'default'} sync"
+        )
+
+    async def fetch_all_user_stats(self):
+        """Fetch all UserStats accounts from the protocol."""
+        logger.info("Starting to fetch all UserStats accounts...")
+
+        try:
+            await self.user_stats_map.subscribe()
+            total_accounts = self.user_stats_map.size()
+            logger.info(f"Successfully fetched {total_accounts} UserStats accounts")
+            return total_accounts
+        except Exception as e:
+            logger.error(f"Error fetching UserStats accounts: {e}")
+            raise
+
+    def get_csv_headers(self):
+        """Define CSV headers based on UserStatsAccount structure."""
+        return [
+            "authority",
+            "user_stats_account_key",
+            "referrer",
+            "total_fee_paid",
+            "total_fee_rebate",
+            "total_token_discount",
+            "total_referee_discount",
+            "total_referrer_reward",
+            "current_epoch_referrer_reward",
+            "next_epoch_ts",
+            "maker_volume_30d",
+            "taker_volume_30d",
+            "filler_volume_30d",
+            "last_maker_volume_30d_ts",
+            "last_taker_volume_30d_ts",
+            "last_filler_volume_30d_ts",
+            "if_staked_quote_asset_amount",
+            "number_of_sub_accounts",
+            "number_of_sub_accounts_created",
+            "is_referrer",
+            "disable_update_perp_bid_ask_twap",
+            "fuel_overflow_status",
+            "fuel_insurance",
+            "fuel_deposits",
+            "fuel_borrows",
+            "fuel_positions",
+            "fuel_taker",
+            "fuel_maker",
+            "if_staked_gov_token_amount",
+            "last_fuel_if_bonus_update_ts",
+        ]
+
+    def extract_user_stats_data(self, user_stats_account, user_stats_pk):
+        """Extract data from UserStatsAccount for CSV export."""
+        fees = getattr(user_stats_account, "fees", None)
+
+        return [
+            str(getattr(user_stats_account, "authority", "")),
+            str(user_stats_pk),
+            str(getattr(user_stats_account, "referrer", "")),
+            getattr(fees, "total_fee_paid", 0) if fees else 0,
+            getattr(fees, "total_fee_rebate", 0) if fees else 0,
+            getattr(fees, "total_token_discount", 0) if fees else 0,
+            getattr(fees, "total_referee_discount", 0) if fees else 0,
+            getattr(fees, "total_referrer_reward", 0) if fees else 0,
+            getattr(fees, "current_epoch_referrer_reward", 0) if fees else 0,
+            getattr(user_stats_account, "next_epoch_ts", 0),
+            getattr(user_stats_account, "maker_volume_30d", 0),
+            getattr(user_stats_account, "taker_volume_30d", 0),
+            getattr(user_stats_account, "filler_volume_30d", 0),
+            getattr(user_stats_account, "last_maker_volume_30d_ts", 0),
+            getattr(user_stats_account, "last_taker_volume_30d_ts", 0),
+            getattr(user_stats_account, "last_filler_volume_30d_ts", 0),
+            getattr(user_stats_account, "if_staked_quote_asset_amount", 0),
+            getattr(user_stats_account, "number_of_sub_accounts", 0),
+            getattr(user_stats_account, "number_of_sub_accounts_created", 0),
+            getattr(user_stats_account, "is_referrer", False),
+            getattr(user_stats_account, "disable_update_perp_bid_ask_twap", False),
+            getattr(user_stats_account, "fuel_overflow_status", 0),
+            getattr(user_stats_account, "fuel_insurance", 0),
+            getattr(user_stats_account, "fuel_deposits", 0),
+            getattr(user_stats_account, "fuel_borrows", 0),
+            getattr(user_stats_account, "fuel_positions", 0),
+            getattr(user_stats_account, "fuel_taker", 0),
+            getattr(user_stats_account, "fuel_maker", 0),
+            getattr(user_stats_account, "if_staked_gov_token_amount", 0),
+            getattr(user_stats_account, "last_fuel_if_bonus_update_ts", 0),
+        ]
+
+    async def export_to_csv(self):
+        """Export all UserStats data to CSV file."""
+        logger.info(f"Exporting data to {self.output_file}")
+
+        try:
+            with open(self.output_file, "w", newline="", encoding="utf-8") as csvfile:
+                writer = csv.writer(csvfile)
+
+                headers = self.get_csv_headers()
+                writer.writerow(headers)
+
+                exported_count = 0
+                for drift_user_stats in self.user_stats_map.values():
+                    try:
+                        user_stats_account = drift_user_stats.get_account()
+                        user_stats_pk = drift_user_stats.user_stats_account_pubkey
+                        row_data = self.extract_user_stats_data(
+                            user_stats_account, user_stats_pk
+                        )
+                        writer.writerow(row_data)
+                        exported_count += 1
+
+                        if exported_count % 1000 == 0:
+                            logger.info(f"Exported {exported_count} records...")
+
+                    except Exception as e:
+                        logger.warning(
+                            f"Error processing user stats for {drift_user_stats.user_stats_account_pubkey}: {e}"
+                        )
+                        continue
+
+                logger.info(
+                    f"Successfully exported {exported_count} UserStats accounts to {self.output_file}"
+                )
+                return exported_count
+
+        except Exception as e:
+            logger.error(f"Error writing to CSV file: {e}")
+            raise
+
+    async def cleanup(self):
+        """Clean up resources."""
+        if self.user_stats_map:
+            self.user_stats_map.unsubscribe()
+        if self.drift_client:
+            await self.drift_client.unsubscribe()
+        await self.connection.close()
+        logger.info("Cleanup completed")
+
+    async def run(self):
+        """Main execution method."""
+        try:
+            logger.info("🚀 Starting Drift UserStats export process...")
+
+            await self.initialize_drift_client()
+            await self.initialize_user_stats_map(use_paginated=True)
+
+            total_accounts = await self.fetch_all_user_stats()
+
+            exported_count = await self.export_to_csv()
+
+            logger.info("✅ Export completed successfully!")
+            logger.info(f"Total accounts found: {total_accounts}")
+            logger.info(f"Records exported: {exported_count}")
+            logger.info(f"Output file: {self.output_file}")
+
+        except Exception as e:
+            logger.error(f"Export failed: {e}", exc_info=True)
+            raise
+        finally:
+            await self.cleanup()
+
+
+async def main():
+    """Main entry point."""
+    parser = argparse.ArgumentParser(
+        description="Export all Drift Protocol UserStats accounts to CSV."
+    )
+
+    timestamp = datetime.now().strftime("%m%d%Y%H%M%S")
+    default_filename = f"{timestamp}_user_stats_full_export.csv"
+
+    DEFAULT_RPC_URL = "https://api.mainnet-beta.solana.com"
+    load_dotenv()
+    rpc_url = os.getenv("RPC_URL", DEFAULT_RPC_URL)
+
+    parser.add_argument(
+        "--rpc-url",
+        type=str,
+        default=rpc_url,
+        help=f"The Solana RPC URL (default: loaded from .env or {DEFAULT_RPC_URL}).",
+    )
+    parser.add_argument(
+        "--output",
+        type=str,
+        default=default_filename,
+        help=f"Output CSV filename (default: {default_filename})",
+    )
+    parser.add_argument(
+        "--verbose", action="store_true", help="Enable verbose (DEBUG level) logging."
+    )
+
+    args = parser.parse_args()
+
+    log_level = logging.DEBUG if args.verbose else logging.INFO
+    logging.basicConfig(
+        level=log_level,
+        format="%(asctime)s - %(levelname)s - %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
+
+    logger.info(f"Using RPC URL: {args.rpc_url}")
+    logger.info(f"Output file: {args.output}")
+
+    exporter = UserStatsExporter(rpc_url=args.rpc_url, output_file=args.output)
+    await exporter.run()
+
+
+if __name__ == "__main__":
+    asyncio.run(main()) 

--- a/projects/2025/06/fuel-recon/test_single_user_fuel.py
+++ b/projects/2025/06/fuel-recon/test_single_user_fuel.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+
+import argparse
+import asyncio
+import os
+import logging
+import time
+from solders.pubkey import Pubkey
+from solders.keypair import Keypair
+from anchorpy import Wallet
+from driftpy.drift_client import DriftClient
+from driftpy.account_subscription_config import AccountSubscriptionConfig
+from driftpy.drift_user import DriftUser
+from driftpy.drift_user_stats import DriftUserStats, UserStatsSubscriptionConfig
+from driftpy.constants.numeric_constants import QUOTE_PRECISION
+from solana.rpc.async_api import AsyncClient
+from solana.rpc.types import MemcmpOpts
+from dotenv import load_dotenv
+
+def get_user_stats_account_public_key(authority: Pubkey, program_id: Pubkey) -> Pubkey:
+    user_stats_account_pk, _ = Pubkey.find_program_address(
+        [b'user_stats', bytes(authority)],
+        program_id
+    )
+    return user_stats_account_pk
+
+async def get_fuel_bonus_for_user(
+    drift_client: DriftClient, 
+    user_public_key: Pubkey, 
+    user_authority: Pubkey
+) -> dict:
+    """
+    Fetches fuel bonus data for a single DriftUser by directly fetching the 
+    UserStats account, inspired by the approach in drift-v2-streamlit.
+
+    This method avoids temporary subscriptions by fetching the UserStats data on-demand
+    and providing it to the DriftUser instance via a temporary mock object.
+
+    Args:
+        drift_client: The main DriftClient instance.
+        user_public_key: The public key of the user account.
+        user_authority: The authority public key for the user.
+
+    Returns:
+        A dictionary containing the fuel bonus data, or None if it fails.
+    """
+    original_get_user_stats = drift_client.get_user_stats
+    drift_user = None
+    fuel_bonus_data = None
+
+    try:
+        # 1. Derive the UserStats public key for the user's authority
+        user_stats_pk = get_user_stats_account_public_key(user_authority, drift_client.program_id)
+        logging.info(f"Derived UserStats PK for authority {user_authority}: {user_stats_pk}")
+
+        # 2. Fetch the UserStats account data directly, avoiding subscriptions
+        logging.info("Fetching UserStats account data directly...")
+        try:
+            user_stats_data = await drift_client.program.account["UserStats"].fetch(user_stats_pk)
+            logging.info("✅ Successfully fetched UserStats data.")
+        except Exception:
+            logging.error(f"❌ Failed to fetch UserStats account {user_stats_pk}. It might not exist for the given authority.", exc_info=True)
+            return None
+
+        # 3. Create a mock subscriber object to hold the fetched data.
+        # This is needed to satisfy the interface expected by DriftUser.get_fuel_bonus()
+        class MockUserStatsSubscriber:
+            def get_account(self):
+                return user_stats_data
+        
+        # 4. Temporarily replace the client's user_stats getter with our mock
+        drift_client.get_user_stats = lambda: MockUserStatsSubscriber()
+        logging.info("Temporarily patched drift_client.get_user_stats with direct-fetch data.")
+
+        # 5. Create and subscribe a DriftUser instance to load its own account data
+        drift_user = DriftUser(
+            drift_client,
+            user_public_key=user_public_key,
+        )
+        await drift_user.subscribe()
+        logging.info(f"Subscribed to DriftUser for user account {user_public_key}.")
+
+        # 6. WORKAROUND: The library's get_fuel_bonus function incorrectly looks for
+        # last_fuel_bonus_update_ts on the UserStats object, but it lives on the
+        # UserAccount object. We patch the fetched UserStats object in memory to include it.
+        user_account_data = drift_user.get_user_account()
+        if user_account_data:
+            user_stats_data.last_fuel_bonus_update_ts = user_account_data.last_fuel_bonus_update_ts
+            logging.info("Applied workaround: Patched UserStats data with last_fuel_bonus_update_ts from UserAccount.")
+        else:
+            logging.error("❌ Could not get UserAccount data to apply workaround.")
+            return None
+
+        # 7. Now, call get_fuel_bonus, which will use our patched getter.
+        # This function is not async, it returns the data directly.
+        fuel_bonus_data = drift_user.get_fuel_bonus(
+            now=int(time.time()),
+            include_settled=True,
+            include_unsettled=True
+        )
+
+    finally:
+        # 8. Crucial cleanup: restore the original method and unsubscribe
+        drift_client.get_user_stats = original_get_user_stats
+        logging.info("Restored original drift_client.get_user_stats.")
+        if drift_user:
+            # We must unsubscribe the DriftUser to close its websocket connection
+            if drift_user.account_subscriber:
+                await drift_user.account_subscriber.unsubscribe()
+            logging.info(f"Unsubscribed from DriftUser for {user_public_key}")
+    
+    return fuel_bonus_data
+
+async def main():
+    parser = argparse.ArgumentParser(description="Fetches and displays the fuel bonus for a specific user subaccount.")
+    DEFAULT_RPC_URL = "https://api.mainnet-beta.solana.com"
+    load_dotenv()
+    rpc_url = os.getenv("RPC_URL", DEFAULT_RPC_URL)
+    parser.add_argument("--rpc-url", type=str, default=rpc_url, help=f"The Solana RPC URL. Defaults to {DEFAULT_RPC_URL} or RPC_URL env var.")
+    parser.add_argument("--authority", type=str, required=True, help="The authority public key of the user to test.")
+    
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+
+    logging.info("🚀 Starting single user fuel test script...")
+    
+    connection = None
+    drift_client = None
+    is_initialized = False
+    try:
+        connection = AsyncClient(args.rpc_url)
+        logging.info(f"🔌 Connecting to RPC endpoint: {args.rpc_url}")
+        
+        # Use a dummy wallet, as we only need to read data
+        wallet = Wallet(Keypair()) 
+        
+        drift_client = DriftClient(
+            connection,
+            wallet,
+            "mainnet",
+            account_subscription=AccountSubscriptionConfig("cached")
+        )
+        await drift_client.subscribe()
+        is_initialized = True
+        logging.info("✅ Successfully subscribed to Drift client.")
+
+        authority_pk_arg = Pubkey.from_string(args.authority)
+        logging.info(f"⏳ Fetching user account(s) for authority: {authority_pk_arg}")
+        
+        # This method of fetching user accounts by authority is consistent with
+        # the approach used in the drift-v2-streamlit repository.
+        user_accounts = await drift_client.program.account["User"].all(
+            filters=[
+                # MemcmpOpts for the User account discriminator
+                MemcmpOpts(offset=0, bytes="TfwwBiNJtao"), 
+                # MemcmpOpts for the authority pubkey
+                MemcmpOpts(offset=8, bytes=bytes(authority_pk_arg))
+            ]
+        )
+        
+        if not user_accounts:
+             logging.error(f"❌ Could not find any user accounts for authority {args.authority}")
+             return
+        
+        logging.info(f"Found {len(user_accounts)} sub-account(s). Processing all of them.")
+        
+        total_fuel = {
+            'insurance_fuel': 0, 
+            'taker_fuel': 0, 
+            'maker_fuel': 0, 
+            'deposit_fuel': 0, 
+            'borrow_fuel': 0, 
+            'position_fuel': 0
+        }
+
+        for user_account_wrapper in user_accounts:
+            user_data = user_account_wrapper.account
+            
+            logging.info(f"⚙️  Processing User Account PK: {user_account_wrapper.public_key} (Sub-ID: {user_data.sub_account_id})")
+
+            try:
+                # The get_fuel_bonus_for_user function is async and should be awaited.
+                fuel_bonus = await get_fuel_bonus_for_user(
+                    drift_client, 
+                    user_account_wrapper.public_key, 
+                    user_data.authority
+                )
+
+                if fuel_bonus:
+                    logging.info(f"    ✅ Fuel bonus data: {fuel_bonus}")
+                    for key, value in fuel_bonus.items():
+                        if key in total_fuel:
+                            total_fuel[key] += value
+                else:
+                    logging.warning(f"    ⚠️ Received no fuel bonus data for sub-account {user_data.sub_account_id}.")
+
+            except Exception as e:
+                logging.error(f"❌ An error occurred while processing sub-account {user_data.sub_account_id}: {e}", exc_info=True)
+
+        logging.info("--------------------------------------------------")
+        logging.info(f"✅ Finished processing all {len(user_accounts)} sub-accounts.")
+        logging.info(f"Total Fuel for authority {authority_pk_arg}:")
+        logging.info(f"{total_fuel}")
+        logging.info("--------------------------------------------------")
+
+    except Exception as e:
+        logging.error(f"An unhandled error occurred: {e}", exc_info=True)
+    finally:
+        if is_initialized:
+            await drift_client.unsubscribe()
+            logging.info("✔️ Drift client unsubscribed.")
+        if connection:
+            await connection.close()
+            logging.info("🔌 RPC connection closed.")
+        logging.info("✨ Script finished.")
+
+if __name__ == "__main__":
+    asyncio.run(main()) 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ solana>=0.30.2
 python-dotenv>=1.0.0
 base58>=2.1.1
 asyncio>=3.4.3
+pandas
+openpyxl


### PR DESCRIPTION
This commit introduces several new scripts aimed at enhancing the export and analysis of user statistics within the Drift Protocol. Key additions include:

- **New Export Scripts**: Added `get_all_UserStats_fuelOnly.py`, `get_all_UserStats_fuelOnly_v2.py`, `get_all_UserStats_fuelOnly_v3.py`, and `get_all_UserStats_v4.py` to facilitate the extraction of user statistics and fuel data from the Drift Protocol. These scripts support various methods for fetching and processing user data, including handling overflow fuel.

- **Comparison Script**: Introduced `compare-snapshots.py` to compare fuel data from two different snapshots, generating a detailed report on discrepancies in user fuel balances.

- **Testing Script**: Added `test_single_user_fuel.py` to fetch and display fuel bonus data for a specific user, providing a focused tool for testing and validation of user statistics.

- **Documentation**: Created `README_fuel_scripts.md` to document the usage and differences between the various user statistics export scripts, enhancing user understanding and guiding effective usage.

These enhancements collectively improve the functionality and usability of the Drift Protocol's user data management and analysis capabilities, allowing for more comprehensive insights into user statistics and fuel data.